### PR TITLE
Fix Google Pixel 2 XL crash

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -112,6 +112,9 @@ while read uevent; do
         if is_charging; then
             for ref in ${uevent%/*}/*; do
                 if [[ -f $ref ]]; then
+                    case $ref in
+                        set_ship_mode) continue; ;;
+                    esac;
                     chmod u+rw $ref;
                     case $(cat $ref) in
                         1       ) c_ON=1;        c_OFF=0;        ;;

--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -112,7 +112,7 @@ while read uevent; do
         if is_charging; then
             for ref in ${uevent%/*}/*; do
                 if [[ -f $ref ]]; then
-                    case $ref in
+                    case ${ref##*/} in
                         set_ship_mode) continue; ;;
                     esac;
                     chmod u+rw $ref;

--- a/system/xbin/mcc
+++ b/system/xbin/mcc
@@ -238,6 +238,12 @@ set_ctrl_refs() {
             set_prop uevent $uevent;
             for ref in ${uevent%/*}/*; do
                 if [[ -f $ref ]]; then
+                    ## toggling some specific files results in crashes, exclude them
+                    case $ref in
+                        ## pixel 2 xl crashes when toggling this file
+                        set_ship_mode) continue; ;;
+                    esac;
+
                     chmod u+rw $ref;
 
                     ## cycling through all, get a possible boolean switch

--- a/system/xbin/mcc
+++ b/system/xbin/mcc
@@ -239,7 +239,7 @@ set_ctrl_refs() {
             for ref in ${uevent%/*}/*; do
                 if [[ -f $ref ]]; then
                     ## toggling some specific files results in crashes, exclude them
-                    case $ref in
+                    case ${ref##*/} in
                         ## pixel 2 xl crashes when toggling this file
                         set_ship_mode) continue; ;;
                     esac;


### PR DESCRIPTION
Pixel 2 XL crashes when toggling the set_ship_mode file. Instruct MCC to ignore the file. I'm not sure if there's a good way to only run this check if it's a Pixel 2 XL, but I don't think this bit of code should interfere with MCC's function on any other device.